### PR TITLE
fix: remove autosave to prevent stale data false positives

### DIFF
--- a/src/payload/collections/pages.ts
+++ b/src/payload/collections/pages.ts
@@ -64,11 +64,7 @@ export const Pages: CollectionConfig<'pages'> = {
     interface: 'PayloadPagesCollection',
   },
   versions: {
-    drafts: {
-      autosave: {
-        interval: 100,
-      },
-    },
+    drafts: true,
   },
   admin: {
     useAsTitle: 'title',


### PR DESCRIPTION
## Summary
- Remove autosave config to fix "document edited by another user" false positives caused by race condition with Payload v3.78.0 stale data detection
- Live preview still works via `RefreshRouteOnSave` on manual save

## Test plan
- [ ] Verify live preview updates on manual save
- [ ] Verify "document edited by another user" modal no longer appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)